### PR TITLE
chore: Revise release CI

### DIFF
--- a/.github/workflows/release-draft.nu
+++ b/.github/workflows/release-draft.nu
@@ -1,0 +1,30 @@
+# aggregate a list of artifacts used for release assets
+let files = ls artifacts | get name
+if (($files | length) == 0) {
+    error make {
+        msg: "No build artifacts found. Release assets are required."
+    }
+}
+print "The following files would be used as release assets:"
+print $files
+
+# Check the tag to be used for the drafted release.
+# The tag used for GitHub releases must match the version published to crates.io.
+# Otherwise, cargo-binstall fails to find the release from which to download standalone binaries.
+let ref = $env.GITHUB_REF
+if (not ($ref | str starts-with 'refs/tags/')) {
+    print $"Not drafting release for ref ($ref) because it is not a tag."
+} else {
+    let version = open Cargo.toml | get package | get version
+    let tag = $ref | str substring 10..
+    if ($version == ($tag | str trim --left --char 'v')) {
+        print $"The tag ($tag) will be used to draft a release."
+        # Use gh-cli tool to draft a release on GitHub.
+        # This command uses the current `git checkout` to get repo info.
+        ^gh release create $tag --draft --generate-notes --title $'Release ($tag)' ...$files
+    } else {
+        error make {
+            msg: $"The tag ($tag) does not match the package version ($version)"
+        }
+    }
+}

--- a/.github/workflows/release-draft.nu
+++ b/.github/workflows/release-draft.nu
@@ -15,13 +15,14 @@ let ref = $env.GITHUB_REF
 if (not ($ref | str starts-with 'refs/tags/')) {
     print $"Not drafting release for ref ($ref) because it is not a tag."
 } else {
-    let version = open Cargo.toml | get package | get version
+    let version = open Cargo.toml | get package.version
     let tag = $ref | str substring 10..
     if ($version == ($tag | str trim --left --char 'v')) {
-        print $"The tag ($tag) will be used to draft a release."
+        let main_version = if ("+" in $version) {$version | split row "+" | get 0} else {$version}
+        print $"The tag ($tag) will be used to draft a release for version ($main_version)."
         # Use gh-cli tool to draft a release on GitHub.
         # This command uses the current `git checkout` to get repo info.
-        ^gh release create $tag --draft --generate-notes --title $'Release ($tag)' ...$files
+        ^gh release create $tag --draft --generate-notes --title $'Release ($main_version)' ...$files
     } else {
         error make {
             msg: $"The tag ($tag) does not match the package version ($version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+     - 'v[0-9]+.[0-9]+.[0-9]+\+?*'
 
 jobs:
   build-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
-  release:
+  build-release:
     strategy:
       fail-fast: false
       matrix:
@@ -40,8 +40,6 @@ jobs:
             os: ubuntu-latest
 
     runs-on: ${{matrix.os}}
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -52,27 +50,56 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
           rustflags: ''  # Keep, as otherwise the defaults will be used
+          cache-key: ${{ matrix.target }}-${{ matrix.format }} # appended to default value
 
       - name: Setup nushell
         uses: hustcer/setup-nu@v3
         with:
           version: "*"
 
+      - name: Install cargo-binstall
+        # cargo-binstall is used on Linux runners to install 'cross' in release.nu
+        # NOTE: we could try the following one-liner in release.nu:
+        #   curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+        # But installing cargo-binstall here ensures it is in PATH before running release.nu
+        if: ${{ runner.os }} == 'Linux'
+        uses: cargo-bins/cargo-binstall@main
+
       - name: Build nur archive
         id: build
-        run: nu .github/workflows/release.nu
+        run: nu .github/workflows/release-build.nu
         env:
           OS: ${{ matrix.os }}
           TARGET: ${{ matrix.target }}
           FORMAT: ${{ matrix.format }}
 
-      - name: Publish archives into draft release
-        uses: softprops/action-gh-release@v2
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      - name: upload built binary as CI artifact
+        uses: actions/upload-artifact@v4
         with:
-          draft: true
-          name: "Release ${{ github.ref_name }}"
-          generate_release_notes: true
-          files: ${{ steps.build.outputs.archive }}
+          name: nur-build-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.format }}
+          path: ${{ steps.build.outputs.archive }}
+
+  draft-release:
+    needs: [build-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nur-build-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Setup nushell
+        uses: hustcer/setup-nu@v3
+        with:
+          version: "*"
+
+      - name: Draft release with artifacts as assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: nu .github/workflows/release-draft.nu

--- a/nurfile
+++ b/nurfile
@@ -116,7 +116,7 @@ def "nur release" [
     print $"Creating release commit and tag '(ansi purple)v($main_version)(ansi reset)'"
     git add Cargo.toml Cargo.lock
     git commit -m $"release: 🔖 v($main_version)"
-    git tag $"v($main_version)"
+    git tag $"v($version)"
 
     print ""
     print "Publishing to crates.io"

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -71,7 +71,7 @@
             Keywords='Installer'
             Description='nur - a taskrunner based on nu shell'
             Manufacturer='David Danier'
-            InstallerVersion='450'
+            InstallerVersion='500'
             Languages='1033'
             Compressed='yes'
             InstallScope='perMachine'


### PR DESCRIPTION
resolves #49 

> [!caution]
> The tag pushed to GitHub _**must match**_ the crate version published to crates.io.
> Otherwise, cargo-binstall fails to find the release assets on GitHub that correspond to the published version on crates.io.
>
> I have added a check to ensure the tag matches the `package.version` specified in Cargo.toml.
> The release CI will fail if this check doesn't pass.

## MacOS and Windows builds remain the same
I was careful to not change builds for MacOS and Windows because the old adage:
> If it isn't broken, then don't fix it.

<details><summary>EDIT: resolved warning about windows builds</summary>
<p>

The Windows aarch64 msi build ~shows~ was showing the following warning:
> D:\a\nur\nur\wix\main.wxs(70) : warning CNDL1143 : Package/@InstallerVersion must be 500 or greater for an ARM or ARM64 package. The value will be changed to 500. You can omit the Package/@InstallerVersion value or specify a value of 500 or greater to eliminate this warning.

There is no equivalent warning for x86_64 msi builds on Windows.

</p>
</details>

## Linux builds use [cross]
The Linux builds now use [cross] to adequately cross-compile with a universally compatible GLIBC version.

I have tested the x86_64 and aarch64 builds on Ubuntu and RPi OS 64-bit (respectively). They now work as expected. Whereas, the current standalone binaries for Linux do not work (for either x86_64 and aarch64); see #49 for more detail.

[cross]: https://github.com/cross-rs/cross

## Use [gh-cli] to draft releases
Using a third-party's code (eg `softprops/action-gh-release`) to draft releases requires you to sacrifice security by extending access to sensitive information.

Instead, this patch employs [gh-cli] (present on every GitHub-hosted runner) to draft a release with the build artifacts as assets (and auto-generated notes/description). Fortunately, the [gh-cli] is [developed officially by GitHub (in Go language)](https://github.com/cli/cli/). Thus, your sensitive information _should_ never be handled by a third-party actor.

This is meant to be a quality of life enhancement.

[gh-cli]: https://cli.github.com/manual/gh_release_create 

## Fixed caching of cargo resources
There were a lot of warnings from `actions-rust-lang/setup-rust-toolchain` about cache conflicts because the `cache-key` (using default value) was not specialized for each job in the matrix. This is now resolved by adding the build target and format (bin or msi) to the `cache-key` used.

I want to point out that caching cargo resources in the release CI seems pointless because
1. The Cargo.lock file should inherently change for each release (which invalidates the previous cache).
2. Using [cross] involves docker containers which cannot employ any cargo resources restored from a cache.

## Tested on my fork
I've tested these changes on my fork. See my [test release](https://github.com/2bndy5/nur/releases/) which was created from a `test-release` branch (based on these changes).

I also tested the `workflow_dispatch` trigger to ensure no release is drafted when the workflow is triggered manually. In this scenario, the workflow's logs will output the file names passed to [gh-cli] as release assets.

Lastly, the build artifacts are available for download (from the workflow run's summary page) and manual testing/inspection. This is done regardless of whatever triggered the workflow.

---
> [!tip]
> You can also add more Linux targets to the release CI's job matrix if you're so inclined. Some Linux users using musl might have to still build from source if not using GNU's C lib. 😉 