### PR TITLE
fix: auto-discovery of dotenv file

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -195,7 +195,11 @@ impl NurEngine {
 
     pub(crate) fn load_dot_env(&mut self, dot_env_path: PathBuf) -> NurResult<()> {
         // Load .env file
-        let env_iter = dotenvy::from_filename_iter(dot_env_path).unwrap();
+        let env_iter = dotenvy::from_filename_iter(&dot_env_path).map_err(|e| {
+            Box::new(NurError::DotenvFileError(format!(
+                "{dot_env_path:?}; {e:?}"
+            )))
+        })?;
 
         // Load variables into the engine environment
         for env_item in env_iter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
         None => {
             let env_path = nur_engine.state.project_path.join(".env");
 
-            if env_path.exists() {
+            if env_path.is_file() {
                 nur_engine.load_dot_env(env_path)?;
             }
         }


### PR DESCRIPTION
resolves #56 

This patch includes the following changes:

- [x] remove the `.unwrap()` from `NurEngine::load_dot_env()` and instead propagate the error using `NurError::DotenvFileError`.
- [x] ensure the discovered path to `<project-root>/.env` is indeed a file that exists. More specifically, it ignores folders named ".env" located in the project's root path.
- [ ] add test(s)