### PR TITLE
build: include binary for armv7-linux-gnueabihf in release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           - aarch64-pc-windows-msvc
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
         format: ['bin']
         include:
           - target: aarch64-apple-darwin
@@ -37,6 +38,8 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: armv7-unknown-linux-gnueabihf
             os: ubuntu-latest
 
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
# Description

Adds prebuilt binary for armv7-linux-gnueabihf to release assets.
It took an hour to build `nur` on my RPi 32-bit OS.
So, I figured a simple patch wouldn't hurt.

I have tested/verified the new release asset (from a CI run on my fork) using my RPi running RPi 32-bit OS.


