### PR TITLE
Add nurfile cli option

### DIFF
--- a/nur-tests/nurfile
+++ b/nur-tests/nurfile
@@ -132,6 +132,10 @@ def "nur test-loading-nurfile-local-nu" [] {
     std assert ((run-nur do-loading-nurfile-local-nu) == "ok")
 }
 
+def "nur test-other-nurfile" [] {
+    std assert ((run-nur --nurfile=other-nurfile do-other-nurfile) == "ok")
+}
+
 # Utils and other commands
 
 def is-windows [] {

--- a/nur-tests/other-nurfile
+++ b/nur-tests/other-nurfile
@@ -1,0 +1,1 @@
+def "nur do-other-nurfile" [] { print "ok" }

--- a/src/args.rs
+++ b/src/args.rs
@@ -35,10 +35,17 @@ pub(crate) fn is_safe_taskname(name: &str) -> bool {
         }))
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct CliArgs {
+    pub(crate) nur_args: Vec<String>,
+    pub(crate) has_task_call: bool,
+    pub(crate) task_call: Vec<String>,
+}
+
 pub(crate) fn gather_commandline_args(
     args: Vec<String>,
-) -> NurResult<(Vec<String>, bool, Vec<String>)> {
-    let mut args_to_nur = Vec::from([String::from(NUR_NAME)]);
+) -> NurResult<CliArgs> {
+    let mut nur_args = Vec::from([String::from(NUR_NAME)]);
     let mut task_call = Vec::from([String::from(NUR_NAME)]);
     let mut has_task_call = false;
     let mut args_iter = args.iter();
@@ -65,10 +72,10 @@ pub(crate) fn gather_commandline_args(
             _ => None,
         };
 
-        args_to_nur.push(arg.clone());
+        nur_args.push(arg.clone());
 
         if let Some(flag_value) = flag_value {
-            args_to_nur.push(flag_value);
+            nur_args.push(flag_value);
         }
     }
 
@@ -83,7 +90,11 @@ pub(crate) fn gather_commandline_args(
         task_call.clear();
     }
 
-    Ok((args_to_nur, has_task_call, task_call))
+    Ok(CliArgs {
+        nur_args,
+        has_task_call,
+        task_call,
+    })
 }
 
 pub(crate) fn parse_commandline_args(
@@ -205,11 +216,11 @@ mod tests {
             String::from("--task-option"),
             String::from("task-value"),
         ];
-        let (nur_args, has_task_call, task_call) = gather_commandline_args(args).unwrap();
-        assert_eq!(nur_args, vec![String::from("nur"), String::from("--quiet")]);
-        assert_eq!(has_task_call, true);
+        let cli_args = gather_commandline_args(args).unwrap();
+        assert_eq!(cli_args.nur_args, vec![String::from("nur"), String::from("--quiet")]);
+        assert_eq!(cli_args.has_task_call, true);
         assert_eq!(
-            task_call,
+            cli_args.task_call,
             vec![
                 String::from("nur"),
                 String::from("some_task_name"),
@@ -227,11 +238,11 @@ mod tests {
             String::from("--task-option"),
             String::from("task-value"),
         ];
-        let (nur_args, has_task_call, task_call) = gather_commandline_args(args).unwrap();
-        assert_eq!(nur_args, vec![String::from("nur")]);
-        assert_eq!(has_task_call, true);
+        let cli_args = gather_commandline_args(args).unwrap();
+        assert_eq!(cli_args.nur_args, vec![String::from("nur")]);
+        assert_eq!(cli_args.has_task_call, true);
         assert_eq!(
-            task_call,
+            cli_args.task_call,
             vec![
                 String::from("nur"),
                 String::from("some_task_name"),
@@ -244,10 +255,10 @@ mod tests {
     #[test]
     fn test_gather_commandline_args_handles_missing_task_name() {
         let args = vec![String::from("nur"), String::from("--help")];
-        let (nur_args, has_task_call, task_call) = gather_commandline_args(args).unwrap();
-        assert_eq!(nur_args, vec![String::from("nur"), String::from("--help")]);
-        assert_eq!(has_task_call, false);
-        assert_eq!(task_call, vec![] as Vec<String>);
+        let cli_args = gather_commandline_args(args).unwrap();
+        assert_eq!(cli_args.nur_args, vec![String::from("nur"), String::from("--help")]);
+        assert_eq!(cli_args.has_task_call, false);
+        assert_eq!(cli_args.task_call, vec![] as Vec<String>);
     }
 
     #[test]
@@ -257,11 +268,11 @@ mod tests {
             String::from("--quiet"),
             String::from("some_task_name"),
         ];
-        let (nur_args, has_task_call, task_call) = gather_commandline_args(args).unwrap();
-        assert_eq!(nur_args, vec![String::from("nur"), String::from("--quiet")]);
-        assert_eq!(has_task_call, true);
+        let cli_args = gather_commandline_args(args).unwrap();
+        assert_eq!(cli_args.nur_args, vec![String::from("nur"), String::from("--quiet")]);
+        assert_eq!(cli_args.has_task_call, true);
         assert_eq!(
-            task_call,
+            cli_args.task_call,
             vec![String::from("nur"), String::from("some_task_name")]
         );
     }
@@ -269,10 +280,10 @@ mod tests {
     #[test]
     fn test_gather_commandline_args_handles_no_args_at_all() {
         let args = vec![String::from("nur")];
-        let (nur_args, has_task_call, task_call) = gather_commandline_args(args).unwrap();
-        assert_eq!(nur_args, vec![String::from("nur")]);
-        assert_eq!(has_task_call, false);
-        assert_eq!(task_call, vec![] as Vec<String>);
+        let cli_args = gather_commandline_args(args).unwrap();
+        assert_eq!(cli_args.nur_args, vec![String::from("nur")]);
+        assert_eq!(cli_args.has_task_call, false);
+        assert_eq!(cli_args.task_call, vec![] as Vec<String>);
     }
 
     fn _create_minimal_engine_for_arg_parsing() -> EngineState {

--- a/src/args.rs
+++ b/src/args.rs
@@ -122,6 +122,7 @@ pub(crate) fn parse_commandline_args(
     {
         // let config_file = call.get_flag_expr("some-flag");
         let list_tasks = call.has_flag(engine_state, &mut stack, "list")?;
+        let nurfile_name = call.get_flag::<Value>(engine_state, &mut stack, "nurfile")?;
         let quiet_execution =
             call.has_flag(engine_state, &mut stack, "quiet")? || env::var(NUR_QUIET).is_ok();
         let attach_stdin = call.has_flag(engine_state, &mut stack, "stdin")?;
@@ -167,6 +168,7 @@ pub(crate) fn parse_commandline_args(
 
         return Ok(NurArgs {
             list_tasks,
+            nurfile_name,
             quiet_execution,
             attach_stdin,
             show_help,
@@ -188,6 +190,7 @@ pub(crate) fn parse_commandline_args(
 #[derive(Debug, Clone)]
 pub(crate) struct NurArgs {
     pub(crate) list_tasks: bool,
+    pub(crate) nurfile_name: Option<Value>,
     pub(crate) quiet_execution: bool,
     pub(crate) attach_stdin: bool,
     pub(crate) show_help: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -42,9 +42,7 @@ pub(crate) struct CliArgs {
     pub(crate) task_call: Vec<String>,
 }
 
-pub(crate) fn gather_commandline_args(
-    args: Vec<String>,
-) -> NurResult<CliArgs> {
+pub(crate) fn gather_commandline_args(args: Vec<String>) -> NurResult<CliArgs> {
     let mut nur_args = Vec::from([String::from(NUR_NAME)]);
     let mut task_call = Vec::from([String::from(NUR_NAME)]);
     let mut has_task_call = false;
@@ -217,7 +215,10 @@ mod tests {
             String::from("task-value"),
         ];
         let cli_args = gather_commandline_args(args).unwrap();
-        assert_eq!(cli_args.nur_args, vec![String::from("nur"), String::from("--quiet")]);
+        assert_eq!(
+            cli_args.nur_args,
+            vec![String::from("nur"), String::from("--quiet")]
+        );
         assert_eq!(cli_args.has_task_call, true);
         assert_eq!(
             cli_args.task_call,
@@ -256,7 +257,10 @@ mod tests {
     fn test_gather_commandline_args_handles_missing_task_name() {
         let args = vec![String::from("nur"), String::from("--help")];
         let cli_args = gather_commandline_args(args).unwrap();
-        assert_eq!(cli_args.nur_args, vec![String::from("nur"), String::from("--help")]);
+        assert_eq!(
+            cli_args.nur_args,
+            vec![String::from("nur"), String::from("--help")]
+        );
         assert_eq!(cli_args.has_task_call, false);
         assert_eq!(cli_args.task_call, vec![] as Vec<String>);
     }
@@ -269,7 +273,10 @@ mod tests {
             String::from("some_task_name"),
         ];
         let cli_args = gather_commandline_args(args).unwrap();
-        assert_eq!(cli_args.nur_args, vec![String::from("nur"), String::from("--quiet")]);
+        assert_eq!(
+            cli_args.nur_args,
+            vec![String::from("nur"), String::from("--quiet")]
+        );
         assert_eq!(cli_args.has_task_call, true);
         assert_eq!(
             cli_args.task_call,

--- a/src/commands/nur.rs
+++ b/src/commands/nur.rs
@@ -19,6 +19,12 @@ impl Command for Nur {
             .description("nur - a taskrunner based on nu shell.")
             .switch("version", "Output version number and exit", Some('v'))
             .switch("list", "List available tasks and then just exit", Some('l'))
+            .named(
+                "nurfile",
+                SyntaxShape::Filepath,
+                "Define which nurfile to search and load (defaults to 'nurfile')",
+                None,
+            )
             .switch(
                 "quiet",
                 "Do not output anything but what the task produces (you can also set the NUR_QUIET environment variable)",

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -24,7 +24,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-pub(crate) fn init_engine_state<P: AsRef<Path>>(project_path: P) -> NurResult<EngineState> {
+pub(crate) fn init_engine_state<P: AsRef<Path>>(run_path: P) -> NurResult<EngineState> {
     let engine_state = nu_cmd_lang::create_default_context();
     let engine_state = nu_command::add_shell_command_context(engine_state);
     let engine_state = nu_cmd_extra::add_extra_command_context(engine_state);
@@ -50,7 +50,7 @@ pub(crate) fn init_engine_state<P: AsRef<Path>>(project_path: P) -> NurResult<En
     );
 
     // First, set up env vars as strings only
-    gather_parent_env_vars(&mut engine_state, project_path.as_ref());
+    gather_parent_env_vars(&mut engine_state, run_path.as_ref());
     engine_state.add_env_var(
         "NU_VERSION".to_string(),
         Value::string(NU_VERSION, Span::unknown()),
@@ -94,6 +94,8 @@ impl NurEngine {
     }
 
     fn _apply_nur_state(&mut self) -> NurResult<()> {
+        self.stack.set_cwd(&self.state.project_path)?;
+
         // Set default scripts path
         self.engine_state.add_env_var(
             NUR_ENV_NU_LIB_DIRS.to_string(),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,4 @@
-use crate::args::{NurArgs, is_safe_taskname, parse_commandline_args};
+use crate::args::is_safe_taskname;
 use crate::errors::NurError::EnteredShellError;
 use crate::errors::{NurError, NurResult};
 use crate::names::{
@@ -81,8 +81,8 @@ pub(crate) struct NurEngine {
 
 impl NurEngine {
     pub(crate) fn new(run_path: PathBuf, args: Vec<String>) -> NurResult<NurEngine> {
-        let engine_state = init_engine_state(&run_path)?;
-        let nur_state = NurState::new(run_path, args)?;
+        let mut engine_state = init_engine_state(&run_path)?;
+        let nur_state = NurState::new(&mut engine_state, run_path, args)?;
 
         let mut nur_engine = NurEngine {
             engine_state,
@@ -185,11 +185,6 @@ impl NurEngine {
                 Value::string(task_name, Span::unknown()),
             );
         }
-    }
-
-    pub(crate) fn parse_args(&mut self) -> NurArgs {
-        parse_commandline_args(&self.state.nur_args.join(" "), &mut self.engine_state)
-            .unwrap_or_else(|_| std::process::exit(1))
     }
 
     pub(crate) fn load_env(&mut self) -> NurResult<()> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -80,7 +80,10 @@ pub(crate) struct NurEngine {
 }
 
 impl NurEngine {
-    pub(crate) fn new(engine_state: EngineState, nur_state: NurState) -> NurResult<NurEngine> {
+    pub(crate) fn new(run_path: PathBuf, args: Vec<String>) -> NurResult<NurEngine> {
+        let engine_state = init_engine_state(&run_path)?;
+        let nur_state = NurState::new(run_path, args)?;
+
         let mut nur_engine = NurEngine {
             engine_state,
             stack: Stack::new(),
@@ -551,10 +554,7 @@ mod tests {
             String::from("some-task"),
             String::from("sub-task"),
         ];
-        let nur_state = NurState::new(temp_dir_path.clone(), args).unwrap();
-        let engine_state = init_engine_state(temp_dir_path).unwrap();
-
-        NurEngine::new(engine_state, nur_state).unwrap()
+        NurEngine::new(temp_dir_path, args).unwrap()
     }
 
     fn _cleanup_nur_engine(temp_dir: &TempDir) {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -183,7 +183,7 @@ impl NurEngine {
     }
 
     pub(crate) fn parse_args(&mut self) -> NurArgs {
-        parse_commandline_args(&self.state.args_to_nur.join(" "), &mut self.engine_state)
+        parse_commandline_args(&self.state.nur_args.join(" "), &mut self.engine_state)
             .unwrap_or_else(|_| std::process::exit(1))
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 use miette::{Diagnostic, Report};
-use nu_protocol::{ParseError, ShellError};
+use nu_protocol::{ParseError, ShellError, Span};
 use thiserror::Error;
 
 pub(crate) type NurResult<T> = Result<T, Box<NurError>>;
@@ -66,5 +66,11 @@ impl From<ShellError> for Box<NurError> {
 impl From<Box<NurError>> for Report {
     fn from(err: Box<NurError>) -> Self {
         Report::new(*err) // move out of the Box
+    }
+}
+
+impl From<Box<ShellError>> for Box<NurError> {
+    fn from(_value: Box<ShellError>) -> Box<NurError> {
+        Box::new(NurError::from(_value.into_chained(Span::unknown())))
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,9 +30,13 @@ pub enum NurError {
     #[diagnostic()]
     TaskNotFound(String),
 
-    #[error("Could not find nurfile in path and parents")]
+    #[error("Nurfile passed via CLI is not valid")]
     #[diagnostic()]
-    NurfileNotFound(),
+    InvalidNurfile(),
+
+    #[error("Could not find {0} in path and parents")]
+    #[diagnostic()]
+    NurfileNotFound(String),
 
     #[error("Entered shell did raise an error")]
     #[diagnostic()]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use crate::commands::Nur;
 use crate::compat::show_nurscripts_hint;
 use crate::engine::NurEngine;
 use crate::errors::NurError;
-use crate::names::NUR_QUIET;
+use crate::names::{NUR_FILE, NUR_QUIET};
 use crate::path::current_dir_from_environment;
 use miette::Result;
 use nu_ansi_term::Color;
@@ -71,7 +71,25 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
 
             std::process::exit(0);
         } else {
-            return Err(miette::ErrReport::from(NurError::NurfileNotFound()));
+            match nur_engine.state.nur_args.nurfile_name.clone() {
+                None => {
+                    return Err(miette::ErrReport::from(NurError::NurfileNotFound(
+                        String::from(NUR_FILE),
+                    )));
+                }
+                Some(Value::String {
+                    val: nurfile_name, ..
+                }) => {
+                    return Err(miette::ErrReport::from(NurError::NurfileNotFound(
+                        nurfile_name,
+                    )));
+                }
+                Some(_) => {
+                    return Err(miette::ErrReport::from(NurError::NurfileNotFound(
+                        String::from(NUR_FILE),
+                    )));
+                }
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,15 +33,12 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
         .use_ansi_coloring
         .get(&nur_engine.engine_state);
 
-    // Parse args
-    let mut parsed_nur_args = nur_engine.parse_args();
-
     #[cfg(feature = "debug")]
-    if parsed_nur_args.debug_output {
+    if nur_engine.state.nur_args.debug_output {
         eprintln!("run path: {:?}", nur_engine.state.run_path);
         eprintln!("project path: {:?}", nur_engine.state.project_path);
         eprintln!();
-        eprintln!("nur args: {:?}", parsed_nur_args);
+        eprintln!("nur args: {:?}", nur_engine.state.nur_args);
         eprintln!("task call: {:?}", nur_engine.state.task_call);
         eprintln!();
         eprintln!("nur config dir: {:?}", nur_engine.state.config_dir);
@@ -69,7 +66,7 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
 
     // Handle execution without project path, only allow to show help, abort otherwise
     if !nur_engine.state.has_project_path {
-        if parsed_nur_args.show_help {
+        if nur_engine.state.nur_args.show_help {
             nur_engine.print_help(&Nur);
 
             std::process::exit(0);
@@ -86,7 +83,7 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
     nur_engine.load_nurfiles()?;
 
     // Handle list tasks
-    if parsed_nur_args.list_tasks {
+    if nur_engine.state.nur_args.list_tasks {
         // TODO: Parse and handle commands without eval
         nur_engine.eval_and_print(
             r#"scope commands
@@ -105,11 +102,11 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
     // Show help if no task call was found
     // (error exit if --help was not passed)
     if !nur_engine.state.has_task_call
-        && parsed_nur_args.run_commands.is_none()
-        && !parsed_nur_args.enter_shell
+        && nur_engine.state.nur_args.run_commands.is_none()
+        && !nur_engine.state.nur_args.enter_shell
     {
         nur_engine.print_help(&Nur);
-        if parsed_nur_args.show_help {
+        if nur_engine.state.nur_args.show_help {
             std::process::exit(0);
         } else {
             std::process::exit(1);
@@ -117,7 +114,7 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
     }
 
     // Handle help
-    if parsed_nur_args.show_help {
+    if nur_engine.state.nur_args.show_help {
         if !nur_engine.state.has_task_call {
             nur_engine.print_help(&Nur);
             std::process::exit(0);
@@ -134,19 +131,19 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
     }
 
     // Ensure we only allow sane calls
-    if nur_engine.state.has_task_call && parsed_nur_args.run_commands.is_some() {
+    if nur_engine.state.has_task_call && nur_engine.state.nur_args.run_commands.is_some() {
         return Err(miette::ErrReport::from(NurError::InvalidNurCall(
             String::from("task call"),
             String::from("--commands/-c"),
         )));
     }
-    if nur_engine.state.has_task_call && parsed_nur_args.enter_shell {
+    if nur_engine.state.has_task_call && nur_engine.state.nur_args.enter_shell {
         return Err(miette::ErrReport::from(NurError::InvalidNurCall(
             String::from("task call"),
             String::from("--enter-shell"),
         )));
     }
-    if parsed_nur_args.run_commands.is_some() && parsed_nur_args.enter_shell {
+    if nur_engine.state.nur_args.run_commands.is_some() && nur_engine.state.nur_args.enter_shell {
         return Err(miette::ErrReport::from(NurError::InvalidNurCall(
             String::from("--commands/-c"),
             String::from("--enter-shell"),
@@ -159,14 +156,14 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
     }
 
     // Prepare input data - if requested
-    let input = if parsed_nur_args.attach_stdin {
+    let input = if nur_engine.state.nur_args.attach_stdin {
         PipelineData::ByteStream(ByteStream::stdin(Span::unknown())?, None)
     } else {
         PipelineData::empty()
     };
 
     // Load .env file from project directory - if requested
-    match parsed_nur_args.dotenv {
+    match &nur_engine.state.nur_args.dotenv {
         None => {
             let env_path = nur_engine.state.project_path.join(".env");
 
@@ -175,21 +172,21 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
 
                 // If we now have NUR_QUIET set, update parsed args state
                 if nur_engine.engine_state.get_env_var(NUR_QUIET).is_some() {
-                    parsed_nur_args.quiet_execution = true;
+                    nur_engine.state.nur_args.quiet_execution = true;
                 }
             }
         }
         Some(Value::String { val, .. }) => {
-            let env_path = nur_engine.state.project_path.join(&val);
+            let env_path = nur_engine.state.project_path.join(val);
             if !env_path.exists() {
                 return Err(miette::ErrReport::from(NurError::DotenvFileError(
-                    val,
+                    val.into(),
                     String::from("dotenv file does not exist"),
                 )));
             }
             if env_path.is_dir() {
                 return Err(miette::ErrReport::from(NurError::DotenvFileError(
-                    val,
+                    val.into(),
                     String::from("dotenv file is actually a directory"),
                 )));
             }
@@ -198,7 +195,7 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
 
             // If we now have NUR_QUIET set, update parsed args state
             if nur_engine.engine_state.get_env_var(NUR_QUIET).is_some() {
-                parsed_nur_args.quiet_execution = true;
+                nur_engine.state.nur_args.quiet_execution = true;
             }
         }
         Some(Value::Nothing { .. }) => {} // nothing to do
@@ -214,25 +211,25 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
 
     // Execute the task
     let exit_code: i32;
-    let run_command = if parsed_nur_args.run_commands.is_some() {
-        parsed_nur_args.run_commands.clone().unwrap().item
+    let run_command = if nur_engine.state.nur_args.run_commands.is_some() {
+        nur_engine.state.nur_args.run_commands.clone().unwrap().item
     } else {
         nur_engine.state.task_call.join(" ")
     };
     #[cfg(feature = "debug")]
-    if parsed_nur_args.debug_output {
+    if nur_engine.state.nur_args.debug_output {
         eprintln!("full command call: {}", run_command);
     }
-    if parsed_nur_args.enter_shell {
+    if nur_engine.state.nur_args.enter_shell {
         exit_code = match nur_engine.run_repl() {
             Ok(_) => 0,
             Err(_) => 1,
         }
-    } else if parsed_nur_args.quiet_execution {
+    } else if nur_engine.state.nur_args.quiet_execution {
         exit_code = nur_engine.eval_and_print(run_command, input)?;
 
         #[cfg(feature = "debug")]
-        if parsed_nur_args.debug_output {
+        if nur_engine.state.nur_args.debug_output {
             println!("Exit code {:?}", exit_code);
         }
     } else {
@@ -241,7 +238,7 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
             "Project path: {}",
             nur_engine.state.project_path.to_str().unwrap()
         );
-        if parsed_nur_args.run_commands.is_some() {
+        if nur_engine.state.nur_args.run_commands.is_some() {
             println!("Running command: {run_command}");
         } else {
             println!("Executing task: {}", nur_engine.get_short_task_name());
@@ -249,7 +246,7 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
         println!();
         exit_code = nur_engine.eval_and_print(run_command, input)?;
         #[cfg(feature = "debug")]
-        if parsed_nur_args.debug_output {
+        if nur_engine.state.nur_args.debug_output {
             println!("Exit code {:?}", exit_code);
         }
         if exit_code == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,9 @@ mod state;
 use crate::commands::Nur;
 use crate::compat::show_nurscripts_hint;
 use crate::engine::NurEngine;
-use crate::engine::init_engine_state;
 use crate::errors::NurError;
 use crate::names::NUR_QUIET;
 use crate::path::current_dir_from_environment;
-use crate::state::NurState;
 use miette::Result;
 use nu_ansi_term::Color;
 use nu_protocol::shell_error::generic::GenericError;
@@ -25,15 +23,10 @@ use std::env;
 use std::process::ExitCode;
 
 fn main() -> Result<ExitCode, miette::ErrReport> {
-    // Initialise nur state
+    // Initialise nur engine with current path
     let run_path = current_dir_from_environment();
+    let mut nur_engine = NurEngine::new(run_path, env::args().collect())?;
 
-    // Create raw nu engine state
-    let engine_state = init_engine_state(&run_path)?;
-
-    // Setup nur engine from engine state
-    let nur_state = NurState::new(run_path, env::args().collect())?;
-    let mut nur_engine = NurEngine::new(engine_state, nur_state)?;
     let use_color = nur_engine
         .engine_state
         .get_config()

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,12 @@ use std::process::ExitCode;
 fn main() -> Result<ExitCode, miette::ErrReport> {
     // Initialise nur state
     let run_path = current_dir_from_environment();
-    let nur_state = NurState::new(run_path, env::args().collect())?;
 
     // Create raw nu engine state
-    let engine_state = init_engine_state(&nur_state.project_path)?;
+    let engine_state = init_engine_state(&run_path)?;
 
     // Setup nur engine from engine state
+    let nur_state = NurState::new(run_path, env::args().collect())?;
     let mut nur_engine = NurEngine::new(engine_state, nur_state)?;
     let use_color = nur_engine
         .engine_state

--- a/src/path.rs
+++ b/src/path.rs
@@ -23,7 +23,7 @@ pub(crate) fn current_dir_from_environment() -> PathBuf {
 
 pub(crate) fn find_project_path<P: AsRef<Path>>(
     cwd: P,
-    nurfile_names: &Vec<&str>,
+    nurfile_names: &Vec<String>,
 ) -> Option<PathBuf> {
     let mut path = cwd.as_ref();
 
@@ -42,7 +42,7 @@ pub(crate) fn find_project_path<P: AsRef<Path>>(
 
 pub(crate) fn find_nurfile<P: AsRef<Path>>(
     project_path_: P,
-    nurfile_names: &Vec<&str>,
+    nurfile_names: &Vec<String>,
 ) -> Option<PathBuf> {
     let project_path = project_path_.as_ref();
 
@@ -74,8 +74,11 @@ mod tests {
 
         // Test the function with the temporary directory as the current working directory
         let expected_path = temp_dir_path.clone();
-        let actual_path =
-            find_project_path(&temp_dir_path, &vec![NUR_FILE, NUR_FILE_DOT_NU]).unwrap();
+        let actual_path = find_project_path(
+            &temp_dir_path,
+            &vec![String::from(NUR_FILE), String::from(NUR_FILE_DOT_NU)],
+        )
+        .unwrap();
         assert_eq!(expected_path, actual_path);
 
         // Clean up
@@ -96,7 +99,11 @@ mod tests {
 
         // Test the function with the subdirectory as the current working directory
         let expected_path = temp_dir_path.clone();
-        let actual_path = find_project_path(&sub_dir, &vec![NUR_FILE, NUR_FILE_DOT_NU]).unwrap();
+        let actual_path = find_project_path(
+            &temp_dir_path,
+            &vec![String::from(NUR_FILE), String::from(NUR_FILE_DOT_NU)],
+        )
+        .unwrap();
         assert_eq!(expected_path, actual_path);
 
         // Clean up
@@ -118,7 +125,11 @@ mod tests {
 
         // Test the function with the subdirectory as the current working directory
         let expected_path = temp_dir_path.clone();
-        let actual_path = find_project_path(&sub_dir, &vec![NUR_FILE, NUR_FILE_DOT_NU]).unwrap();
+        let actual_path = find_project_path(
+            &temp_dir_path,
+            &vec![String::from(NUR_FILE), String::from(NUR_FILE_DOT_NU)],
+        )
+        .unwrap();
         assert_eq!(expected_path, actual_path);
 
         // Clean up
@@ -133,7 +144,10 @@ mod tests {
         let temp_dir_path = temp_dir.path().to_path_buf();
 
         // Test the function with the temporary directory as the current working directory
-        match find_project_path(&temp_dir_path, &vec![NUR_FILE, NUR_FILE_DOT_NU]) {
+        match find_project_path(
+            &temp_dir_path,
+            &vec![String::from(NUR_FILE), String::from(NUR_FILE_DOT_NU)],
+        ) {
             Some(_) => panic!("Expected an error, but got Ok"),
             None => (),
         }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,4 +1,3 @@
-use crate::names::{NUR_FILE, NUR_FILE_DOT_NU, NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU};
 use std::path::{Path, PathBuf};
 
 /// Get the directory where the Nushell executable is located.
@@ -22,11 +21,14 @@ pub(crate) fn current_dir_from_environment() -> PathBuf {
     current_exe_directory()
 }
 
-pub(crate) fn find_project_path<P: AsRef<Path>>(cwd: P) -> Option<PathBuf> {
+pub(crate) fn find_project_path<P: AsRef<Path>>(
+    cwd: P,
+    nurfile_names: &Vec<&str>,
+) -> Option<PathBuf> {
     let mut path = cwd.as_ref();
 
     loop {
-        if find_nurfile(path).is_some() {
+        if find_nurfile(path, nurfile_names).is_some() {
             return Some(path.to_path_buf());
         }
 
@@ -38,26 +40,16 @@ pub(crate) fn find_project_path<P: AsRef<Path>>(cwd: P) -> Option<PathBuf> {
     }
 }
 
-pub(crate) fn find_nurfile<P: AsRef<Path>>(project_path_: P) -> Option<PathBuf> {
+pub(crate) fn find_nurfile<P: AsRef<Path>>(
+    project_path_: P,
+    nurfile_names: &Vec<&str>,
+) -> Option<PathBuf> {
     let project_path = project_path_.as_ref();
 
-    for nur_file_name in [NUR_FILE, NUR_FILE_DOT_NU] {
+    for nur_file_name in nurfile_names {
         let nur_file_path = project_path.join(nur_file_name);
         if nur_file_path.exists() {
             return Some(nur_file_path);
-        }
-    }
-
-    None
-}
-
-pub(crate) fn find_local_nurfile<P: AsRef<Path>>(project_path_: P) -> Option<PathBuf> {
-    let project_path = project_path_.as_ref();
-
-    for nur_local_file_name in [NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU] {
-        let nur_local_file_path = project_path.join(nur_local_file_name);
-        if nur_local_file_path.exists() {
-            return Some(nur_local_file_path);
         }
     }
 
@@ -70,6 +62,8 @@ mod tests {
     use std::fs::{File, create_dir};
     use tempfile::tempdir;
 
+    use crate::names::{NUR_FILE, NUR_FILE_DOT_NU};
+
     #[test]
     fn test_find_project_path() {
         // Create a temporary directory and a "nurfile" inside it
@@ -80,7 +74,8 @@ mod tests {
 
         // Test the function with the temporary directory as the current working directory
         let expected_path = temp_dir_path.clone();
-        let actual_path = find_project_path(&temp_dir_path).unwrap();
+        let actual_path =
+            find_project_path(&temp_dir_path, &vec![NUR_FILE, NUR_FILE_DOT_NU]).unwrap();
         assert_eq!(expected_path, actual_path);
 
         // Clean up
@@ -101,7 +96,7 @@ mod tests {
 
         // Test the function with the subdirectory as the current working directory
         let expected_path = temp_dir_path.clone();
-        let actual_path = find_project_path(&sub_dir).unwrap();
+        let actual_path = find_project_path(&sub_dir, &vec![NUR_FILE, NUR_FILE_DOT_NU]).unwrap();
         assert_eq!(expected_path, actual_path);
 
         // Clean up
@@ -123,7 +118,7 @@ mod tests {
 
         // Test the function with the subdirectory as the current working directory
         let expected_path = temp_dir_path.clone();
-        let actual_path = find_project_path(&sub_dir).unwrap();
+        let actual_path = find_project_path(&sub_dir, &vec![NUR_FILE, NUR_FILE_DOT_NU]).unwrap();
         assert_eq!(expected_path, actual_path);
 
         // Clean up
@@ -138,7 +133,7 @@ mod tests {
         let temp_dir_path = temp_dir.path().to_path_buf();
 
         // Test the function with the temporary directory as the current working directory
-        match find_project_path(&temp_dir_path) {
+        match find_project_path(&temp_dir_path, &vec![NUR_FILE, NUR_FILE_DOT_NU]) {
             Some(_) => panic!("Expected an error, but got Ok"),
             None => (),
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,8 +4,9 @@ use crate::args::{NurArgs, gather_commandline_args, parse_commandline_args};
 use crate::errors::NurResult;
 use crate::names::{
     NUR_CONFIG_CONFIG_FILENAME, NUR_CONFIG_DIR, NUR_CONFIG_ENV_FILENAME, NUR_CONFIG_LIB_PATH,
+    NUR_FILE, NUR_FILE_DOT_NU, NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU,
 };
-use crate::path::{find_local_nurfile, find_nurfile, find_project_path};
+use crate::path::{find_nurfile, find_project_path};
 use std::path::PathBuf;
 
 #[derive(Clone)]
@@ -34,8 +35,16 @@ impl NurState {
         run_path: PathBuf,
         args: Vec<String>,
     ) -> NurResult<Self> {
+        // Parse args into bits
+        let cli_args = gather_commandline_args(args)?;
+        let nur_args = parse_commandline_args(&cli_args.nur_args.join(" "), engine_state)?;
+
+        // Define nurfile names
+        let nurfile_names = vec![NUR_FILE, NUR_FILE_DOT_NU];
+        let nurfile_local_names = vec![NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU];
+
         // Get initial directory details
-        let found_project_path = find_project_path(&run_path);
+        let found_project_path = find_project_path(&run_path, &nurfile_names);
         let has_project_path = found_project_path.is_some();
         let project_path = found_project_path.unwrap_or(run_path.clone());
 
@@ -46,12 +55,8 @@ impl NurState {
         let config_path = config_dir.join(NUR_CONFIG_CONFIG_FILENAME);
 
         // Set nurfiles
-        let nurfile_path = find_nurfile(&project_path);
-        let local_nurfile_path = find_local_nurfile(&project_path);
-
-        // Parse args into bits
-        let cli_args = gather_commandline_args(args)?;
-        let nur_args = parse_commandline_args(&cli_args.nur_args.join(" "), engine_state)?;
+        let nurfile_path = find_nurfile(&project_path, &nurfile_names);
+        let local_nurfile_path = find_nurfile(&project_path, &nurfile_local_names);
 
         Ok(NurState {
             run_path,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,8 @@
+use nu_protocol::Value;
 use nu_protocol::engine::EngineState;
 
 use crate::args::{NurArgs, gather_commandline_args, parse_commandline_args};
-use crate::errors::NurResult;
+use crate::errors::{NurError, NurResult};
 use crate::names::{
     NUR_CONFIG_CONFIG_FILENAME, NUR_CONFIG_DIR, NUR_CONFIG_ENV_FILENAME, NUR_CONFIG_LIB_PATH,
     NUR_FILE, NUR_FILE_DOT_NU, NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU,
@@ -40,8 +41,31 @@ impl NurState {
         let nur_args = parse_commandline_args(&cli_args.nur_args.join(" "), engine_state)?;
 
         // Define nurfile names
-        let nurfile_names = vec![NUR_FILE, NUR_FILE_DOT_NU];
-        let nurfile_local_names = vec![NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU];
+        let nurfile_names: Vec<String>;
+        let nurfile_local_names: Vec<String>;
+        match nur_args.nurfile_name.clone() {
+            None => {
+                nurfile_names = vec![String::from(NUR_FILE), String::from(NUR_FILE_DOT_NU)];
+                nurfile_local_names = vec![
+                    String::from(NUR_LOCAL_FILE),
+                    String::from(NUR_LOCAL_FILE_DOT_NU),
+                ];
+            }
+            Some(Value::String {
+                val: nurfile_name, ..
+            }) => {
+                nurfile_names = vec![nurfile_name.clone()];
+                if nurfile_name.ends_with(".nu") {
+                    let nurfile_basename = nurfile_name.strip_suffix(".nu").unwrap();
+                    nurfile_local_names = vec![format!("{nurfile_basename}.local.nu")];
+                } else {
+                    nurfile_local_names = vec![format!("{nurfile_name}.local")];
+                }
+            }
+            Some(_) => {
+                return Err(Box::new(NurError::InvalidNurfile()));
+            }
+        }
 
         // Get initial directory details
         let found_project_path = find_project_path(&run_path, &nurfile_names);
@@ -239,5 +263,22 @@ mod tests {
         assert_eq!(state.nur_args.show_help, true);
         assert_eq!(state.has_task_call, false);
         assert_eq!(state.task_call, vec![] as Vec<String>);
+    }
+
+    #[test]
+    fn test_nur_state_with_nurfile_option() {
+        let temp_dir = tempdir().unwrap();
+        let temp_dir_path = temp_dir.path().to_path_buf();
+
+        // Setup test
+        let args = vec![String::from("nur"), String::from("--nurfile=other-nurfile")];
+        let mut engine_state = init_engine_state(temp_dir_path.clone()).unwrap();
+        let state = NurState::new(&mut engine_state, temp_dir_path.clone(), args).unwrap();
+
+        // Check nurfile name is set
+        assert_eq!(
+            state.nur_args.nurfile_name.unwrap().as_str().unwrap(),
+            "other-nurfile"
+        );
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,6 @@
-use crate::args::gather_commandline_args;
+use nu_protocol::engine::EngineState;
+
+use crate::args::{NurArgs, gather_commandline_args, parse_commandline_args};
 use crate::errors::NurResult;
 use crate::names::{
     NUR_CONFIG_CONFIG_FILENAME, NUR_CONFIG_DIR, NUR_CONFIG_ENV_FILENAME, NUR_CONFIG_LIB_PATH,
@@ -20,14 +22,18 @@ pub(crate) struct NurState {
     pub(crate) nurfile_path: Option<PathBuf>,
     pub(crate) local_nurfile_path: Option<PathBuf>,
 
-    pub(crate) nur_args: Vec<String>,
+    pub(crate) nur_args: NurArgs,
     pub(crate) has_task_call: bool,
     pub(crate) task_call: Vec<String>,
     pub(crate) task_name: Option<String>, // full task name, like "nur some-task"
 }
 
 impl NurState {
-    pub(crate) fn new(run_path: PathBuf, args: Vec<String>) -> NurResult<Self> {
+    pub(crate) fn new(
+        engine_state: &mut EngineState,
+        run_path: PathBuf,
+        args: Vec<String>,
+    ) -> NurResult<Self> {
         // Get initial directory details
         let found_project_path = find_project_path(&run_path);
         let has_project_path = found_project_path.is_some();
@@ -45,6 +51,7 @@ impl NurState {
 
         // Parse args into bits
         let cli_args = gather_commandline_args(args)?;
+        let nur_args = parse_commandline_args(&cli_args.nur_args.join(" "), engine_state)?;
 
         Ok(NurState {
             run_path,
@@ -59,7 +66,7 @@ impl NurState {
             nurfile_path,
             local_nurfile_path,
 
-            nur_args: cli_args.nur_args,
+            nur_args,
             has_task_call: cli_args.has_task_call,
             task_call: cli_args.task_call,
             task_name: None,
@@ -69,7 +76,10 @@ impl NurState {
 
 #[cfg(test)]
 mod tests {
-    use crate::names::{NUR_FILE, NUR_FILE_DOT_NU, NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU};
+    use crate::{
+        engine::init_engine_state,
+        names::{NUR_FILE, NUR_FILE_DOT_NU, NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU},
+    };
 
     use super::*;
     use std::fs::File;
@@ -91,7 +101,8 @@ mod tests {
             String::from("some_task"),
             String::from("task_arg"),
         ];
-        let state = NurState::new(temp_dir_path.clone(), args).unwrap();
+        let mut engine_state = init_engine_state(temp_dir_path.clone()).unwrap();
+        let state = NurState::new(&mut engine_state, temp_dir_path.clone(), args).unwrap();
 
         // Check everything works out
         assert_eq!(state.run_path, temp_dir_path);
@@ -109,10 +120,7 @@ mod tests {
             temp_dir_path.join(NUR_LOCAL_FILE)
         );
 
-        assert_eq!(
-            state.nur_args,
-            vec![String::from("nur"), String::from("--quiet"),]
-        );
+        assert_eq!(state.nur_args.quiet_execution, true);
         assert_eq!(state.has_task_call, true);
         assert_eq!(
             state.task_call,
@@ -143,7 +151,8 @@ mod tests {
             String::from("some_task"),
             String::from("task_arg"),
         ];
-        let state = NurState::new(temp_dir_path.clone(), args).unwrap();
+        let mut engine_state = init_engine_state(temp_dir_path.clone()).unwrap();
+        let state = NurState::new(&mut engine_state, temp_dir_path.clone(), args).unwrap();
 
         // Check nurfile paths are ok
         assert_eq!(
@@ -171,7 +180,8 @@ mod tests {
             String::from("some_task"),
             String::from("task_arg"),
         ];
-        let state = NurState::new(temp_dir_path.clone(), args).unwrap();
+        let mut engine_state = init_engine_state(temp_dir_path.clone()).unwrap();
+        let state = NurState::new(&mut engine_state, temp_dir_path.clone(), args).unwrap();
 
         // Check everything works out
         assert_eq!(state.run_path, temp_dir_path);
@@ -186,10 +196,7 @@ mod tests {
         assert!(state.nurfile_path.is_none());
         assert!(state.local_nurfile_path.is_none());
 
-        assert_eq!(
-            state.nur_args,
-            vec![String::from("nur"), String::from("--quiet"),]
-        );
+        assert_eq!(state.nur_args.quiet_execution, true);
         assert_eq!(state.has_task_call, true);
         assert_eq!(
             state.task_call,
@@ -208,7 +215,8 @@ mod tests {
 
         // Setup test
         let args = vec![String::from("nur"), String::from("--help")];
-        let state = NurState::new(temp_dir_path.clone(), args).unwrap();
+        let mut engine_state = init_engine_state(temp_dir_path.clone()).unwrap();
+        let state = NurState::new(&mut engine_state, temp_dir_path.clone(), args).unwrap();
 
         // Check everything works out
         assert_eq!(state.run_path, temp_dir_path);
@@ -223,10 +231,7 @@ mod tests {
         assert!(state.nurfile_path.is_none());
         assert!(state.local_nurfile_path.is_none());
 
-        assert_eq!(
-            state.nur_args,
-            vec![String::from("nur"), String::from("--help"),]
-        );
+        assert_eq!(state.nur_args.show_help, true);
         assert_eq!(state.has_task_call, false);
         assert_eq!(state.task_call, vec![] as Vec<String>);
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,7 +20,7 @@ pub(crate) struct NurState {
     pub(crate) nurfile_path: Option<PathBuf>,
     pub(crate) local_nurfile_path: Option<PathBuf>,
 
-    pub(crate) args_to_nur: Vec<String>,
+    pub(crate) nur_args: Vec<String>,
     pub(crate) has_task_call: bool,
     pub(crate) task_call: Vec<String>,
     pub(crate) task_name: Option<String>, // full task name, like "nur some-task"
@@ -44,7 +44,7 @@ impl NurState {
         let local_nurfile_path = find_local_nurfile(&project_path);
 
         // Parse args into bits
-        let (args_to_nur, has_task_call, task_call) = gather_commandline_args(args)?;
+        let cli_args = gather_commandline_args(args)?;
 
         Ok(NurState {
             run_path,
@@ -59,9 +59,9 @@ impl NurState {
             nurfile_path,
             local_nurfile_path,
 
-            args_to_nur,
-            has_task_call,
-            task_call,
+            nur_args: cli_args.nur_args,
+            has_task_call: cli_args.has_task_call,
+            task_call: cli_args.task_call,
             task_name: None,
         })
     }
@@ -110,7 +110,7 @@ mod tests {
         );
 
         assert_eq!(
-            state.args_to_nur,
+            state.nur_args,
             vec![String::from("nur"), String::from("--quiet"),]
         );
         assert_eq!(state.has_task_call, true);
@@ -187,7 +187,7 @@ mod tests {
         assert!(state.local_nurfile_path.is_none());
 
         assert_eq!(
-            state.args_to_nur,
+            state.nur_args,
             vec![String::from("nur"), String::from("--quiet"),]
         );
         assert_eq!(state.has_task_call, true);
@@ -224,7 +224,7 @@ mod tests {
         assert!(state.local_nurfile_path.is_none());
 
         assert_eq!(
-            state.args_to_nur,
+            state.nur_args,
             vec![String::from("nur"), String::from("--help"),]
         );
         assert_eq!(state.has_task_call, false);


### PR DESCRIPTION
# Description

Add ability to set nurfile name via CLI.

You can now use `nur --nurfile=some-file-name` to change which file is loaded as the `nurfile`. Also a local version is loaded as well if it exists.

Fixes: #82 
