### PR TITLE
Improve --enter-shell text output

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -468,6 +468,7 @@ impl NurEngine {
     }
 
     pub(crate) fn run_repl(&mut self) -> NurResult<()> {
+        self.engine_state.is_interactive = true;
         match evaluate_repl(
             &mut self.engine_state,
             self.stack.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,15 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
         eprintln!("full command call: {}", run_command);
     }
     if nur_engine.state.nur_args.enter_shell {
+        if !nur_engine.state.nur_args.quiet_execution {
+            println!("nur version {}", env!("CARGO_PKG_VERSION"));
+            println!(
+                "Project path: {}",
+                nur_engine.state.project_path.to_str().unwrap()
+            );
+            println!("Entering repl shell...");
+            println!();
+        }
         exit_code = match nur_engine.run_repl() {
             Ok(_) => 0,
             Err(_) => 1,

--- a/src/nu-scripts/default_nur_config.nu
+++ b/src/nu-scripts/default_nur_config.nu
@@ -2,3 +2,6 @@
 
 # We don't set anything special here
 $env.config = {}
+
+# ...but we remove the startup banner
+$env.config.show_banner = false

--- a/src/nu-scripts/default_nur_env.nu
+++ b/src/nu-scripts/default_nur_env.nu
@@ -6,5 +6,8 @@ $env.NU_LIB_DIRS = [
     $nur.default-lib-dir
 ]
 
+# Ensure indicator is set.
+$env.PROMPT_INDICATOR = "> "
+
 # To load from a custom file you can use:
 # source ($nur.project-path | path join 'custom.nu')


### PR DESCRIPTION
# Description

This includes the following changes:
* The prompt now includes "> " to separate the working directory from the text input
* The nu banner is gone
* Instead the nur state like project path and nur version is shown
