### PR TITLE
Show task list as table including the description

### DIFF
--- a/scripts/nur-completions.bash
+++ b/scripts/nur-completions.bash
@@ -31,7 +31,7 @@ _comp_cmd_nur()
             return 0
         else
             local tasks
-            IFS=$'\n' tasks=$( nur --list )
+            IFS=$'\n' tasks=$( nur --list --quiet )
             local tasks_string=$( printf "%s\t" "${tasks[@]}" )
             COMPREPLY=( $( compgen -W "${tasks_string}" -- "${cur}" ) )
         fi

--- a/scripts/nur-completions.nu
+++ b/scripts/nur-completions.nu
@@ -1,5 +1,5 @@
 def "nu-complete nur task-names" [] {
-  ^nur --list | lines
+  ^nur --list --quiet | lines
 }
 
 # nur - a taskrunner based on nu shell.

--- a/scripts/nur-completions.zsh
+++ b/scripts/nur-completions.zsh
@@ -3,7 +3,7 @@
 _nur_tasks() {
     [[ $PREFIX = -* ]] && return 1
     local tasks; tasks=(
-        "${(@f)$(_call_program commands nur --list)}"
+        "${(@f)$(_call_program commands nur --list --quiet)}"
     )
 
     _describe 'nur tasks' tasks

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,16 +103,34 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
     // Handle list tasks
     if nur_engine.state.nur_args.list_tasks {
         // TODO: Parse and handle commands without eval
-        nur_engine.eval_and_print(
-            r#"scope commands
-            | where name starts-with "nur " and type == "custom"
-            | get name
-            | each { |it| $it | str substring 4.. }
-            | sort
-            | each { |it| print $it };
-            null"#,
-            PipelineData::empty(),
-        )?;
+        if nur_engine.state.nur_args.quiet_execution {
+            nur_engine.eval_and_print(
+                r#"scope commands
+                | where name starts-with "nur " and type == "custom"
+                | get name
+                | each { |it| $it | str substring 4.. }
+                | sort
+                | each { |it| print $it };
+                null"#,
+                PipelineData::empty(),
+            )?;
+        } else {
+            println!("nur version {}", env!("CARGO_PKG_VERSION"));
+            println!(
+                "Project path: {}",
+                nur_engine.state.project_path.to_str().unwrap()
+            );
+            println!();
+            nur_engine.eval_and_print(
+                r#"scope commands
+                | where name starts-with "nur " and type == "custom"
+                | select name description
+                | update name { |row| $row.name | str substring 4.. }
+                | sort-by name
+                | table --index false"#,
+                PipelineData::empty(),
+            )?;
+        }
 
         std::process::exit(0);
     }


### PR DESCRIPTION
# Description

nur --list now shows a table including the description. Use nur --list --quiet to get back the old behaviour.

Also updates the completion scripts to use `--quiet`.

Fixes: https://github.com/nur-taskrunner/nur/issues/85
