### PR TITLE
Add autoload

### DIFF
--- a/nur-tests/.nur/autoload/auto_loaded.nu
+++ b/nur-tests/.nur/autoload/auto_loaded.nu
@@ -1,0 +1,1 @@
+def "nur do-autoload" [] { print "ok" }

--- a/nur-tests/nurfile
+++ b/nur-tests/nurfile
@@ -136,6 +136,10 @@ def "nur test-other-nurfile" [] {
     std assert ((run-nur --nurfile=other-nurfile do-other-nurfile) == "ok")
 }
 
+def "nur test-autoload" [] {
+    std assert ((run-nur do-autoload) == "ok")
+}
+
 # Utils and other commands
 
 def is-windows [] {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -341,15 +341,20 @@ impl NurEngine {
 
     fn _parse_nu_script(
         &mut self,
-        file_path: Option<&str>,
+        file_path: Option<PathBuf>,
         contents: String,
     ) -> NurResult<Arc<Block>> {
-        if let Some(file_path_value) = file_path {
-            self.engine_state.file = Some(PathBuf::from(file_path_value));
-        }
-
         let mut working_set = StateWorkingSet::new(&self.engine_state);
-        let block = nu_parser::parse(&mut working_set, file_path, &contents.into_bytes(), false);
+        let fname = match file_path {
+            Some(path) => path.to_str().map(|s| s.to_string()),
+            None => None,
+        };
+        let block = nu_parser::parse(
+            &mut working_set,
+            fname.as_deref(),
+            &contents.into_bytes(),
+            false,
+        );
 
         if working_set.parse_errors.is_empty() {
             let delta = working_set.render();
@@ -384,7 +389,7 @@ impl NurEngine {
 
     fn _eval<S: ToString>(
         &mut self,
-        file_path: Option<&str>,
+        file_path: Option<PathBuf>,
         contents: S,
         input: PipelineData,
         print: bool,
@@ -396,9 +401,13 @@ impl NurEngine {
             return Ok(0);
         }
 
-        let block = self._parse_nu_script(file_path, str_contents)?;
+        let prev_file = self.engine_state.file.take();
+        self.engine_state.file = file_path.clone();
 
+        let block = self._parse_nu_script(file_path, str_contents)?;
         let result = self._execute_block(&block, input)?;
+
+        self.engine_state.file = prev_file;
 
         // Merge env is requested
         if merge_env {
@@ -461,24 +470,20 @@ impl NurEngine {
         self._eval(None, contents, input, false, true)
     }
 
-    pub(crate) fn source<P: AsRef<Path>>(
-        &mut self,
-        file_path: P,
-        input: PipelineData,
-    ) -> NurResult<i32> {
+    pub(crate) fn source(&mut self, file_path: PathBuf, input: PipelineData) -> NurResult<i32> {
         let contents = fs::read_to_string(&file_path)?;
 
-        self._eval(file_path.as_ref().to_str(), contents, input, false, false)
+        self._eval(Some(file_path), contents, input, false, false)
     }
 
-    pub(crate) fn source_and_merge_env<P: AsRef<Path>>(
+    pub(crate) fn source_and_merge_env(
         &mut self,
-        file_path: P,
+        file_path: PathBuf,
         input: PipelineData,
     ) -> NurResult<i32> {
         let contents = fs::read_to_string(&file_path)?;
 
-        self._eval(file_path.as_ref().to_str(), contents, input, false, true)
+        self._eval(Some(file_path), contents, input, false, true)
     }
 
     pub(crate) fn has_def<S: AsRef<str>>(&self, name: S) -> bool {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -123,9 +123,21 @@ impl NurEngine {
 
         // Set up the $nu constant before evaluating any files
         // (those may need to have $nu available to execute them)
-        self.engine_state.generate_nu_constant();
+        self._generate_nu_constant()?;
 
         // Set up the $nur constant record (like $nu)
+        self._generate_nur_constant()?;
+
+        Ok(())
+    }
+
+    fn _generate_nu_constant(&mut self) -> NurResult<()> {
+        self.engine_state.generate_nu_constant();
+
+        Ok(())
+    }
+
+    fn _generate_nur_constant(&mut self) -> NurResult<()> {
         let mut nur_record = Record::new();
         nur_record.push(
             NUR_VAR_RUN_PATH,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,10 +3,11 @@ use crate::errors::NurError::EnteredShellError;
 use crate::errors::{NurError, NurResult};
 use crate::names::{
     NUR_ENV_NU_LIB_DIRS, NUR_ENV_NUR_TASK_CALL, NUR_ENV_NUR_TASK_NAME, NUR_ENV_NUR_VERSION,
-    NUR_NAME, NUR_VAR_CONFIG_DIR, NUR_VAR_DEFAULT_LIB_DIR, NUR_VAR_PROJECT_PATH, NUR_VAR_RUN_PATH,
-    NUR_VAR_TASK_NAME,
+    NUR_NAME, NUR_VAR_AUTOLOAD_DIRS, NUR_VAR_CONFIG_DIR, NUR_VAR_DEFAULT_LIB_DIR,
+    NUR_VAR_PROJECT_PATH, NUR_VAR_RUN_PATH, NUR_VAR_TASK_NAME,
 };
 use crate::nu_version::NU_VERSION;
+use crate::path::read_and_sort_directory;
 use crate::scripts::{get_default_nur_config, get_default_nur_env};
 use crate::state::NurState;
 use dotenvy::{Error as DotenvError, from_filename_iter as dotenv_from_filename_iter};
@@ -174,6 +175,17 @@ impl NurEngine {
                 Span::unknown(),
             ),
         );
+        nur_record.push(
+            NUR_VAR_AUTOLOAD_DIRS,
+            Value::list(
+                self.state
+                    .autoload_dirs
+                    .iter()
+                    .map(|path| Value::string(path.to_string_lossy(), Span::unknown()))
+                    .collect(),
+                Span::unknown(),
+            ),
+        );
         let mut working_set = StateWorkingSet::new(&self.engine_state);
         let nur_var_id = working_set.add_variable(
             NUR_NAME.as_bytes().into(),
@@ -184,6 +196,29 @@ impl NurEngine {
         self.stack
             .add_var(nur_var_id, Value::record(nur_record, Span::unknown()));
         self.engine_state.merge_delta(working_set.render())?;
+
+        Ok(())
+    }
+
+    pub(crate) fn read_autoload_files(&mut self) -> NurResult<()> {
+        self.state
+            .autoload_dirs
+            .clone()
+            .iter()
+            .for_each(|autoload_dir| {
+                if autoload_dir.exists() {
+                    let entries = read_and_sort_directory(autoload_dir);
+                    if let Ok(entries) = entries {
+                        for entry in entries {
+                            if !entry.ends_with(".nu") {
+                                continue;
+                            }
+                            let path = autoload_dir.join(entry);
+                            let _ = self.source_and_merge_env(path, PipelineData::Empty);
+                        }
+                    }
+                }
+            });
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,9 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
     nur_engine.load_env()?;
     nur_engine.load_config()?;
 
+    // Load autoload files
+    nur_engine.read_autoload_files()?;
+
     // Load task files
     nur_engine.load_nurfiles()?;
 

--- a/src/names.rs
+++ b/src/names.rs
@@ -5,6 +5,7 @@ pub(crate) const NUR_CONFIG_DIR: &str = ".nur";
 pub(crate) const NUR_CONFIG_LIB_PATH: &str = "scripts";
 pub(crate) const NUR_CONFIG_CONFIG_FILENAME: &str = "config.nu";
 pub(crate) const NUR_CONFIG_ENV_FILENAME: &str = "env.nu";
+pub(crate) const NUR_CONFIG_AUTOLOAD_DIR: &str = "autoload";
 
 // $env variable names
 pub(crate) const NUR_ENV_NU_LIB_DIRS: &str = "NU_LIB_DIRS";
@@ -19,6 +20,7 @@ pub(crate) const NUR_VAR_PROJECT_PATH: &str = "project-path";
 pub(crate) const NUR_VAR_TASK_NAME: &str = "task-name";
 pub(crate) const NUR_VAR_CONFIG_DIR: &str = "config-dir";
 pub(crate) const NUR_VAR_DEFAULT_LIB_DIR: &str = "default-lib-dir";
+pub(crate) const NUR_VAR_AUTOLOAD_DIRS: &str = "autoload-dirs";
 
 // nurfile names
 pub(crate) const NUR_FILE: &str = "nurfile";

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,3 +1,5 @@
+use std::fs;
+use std::io::Result;
 use std::path::{Path, PathBuf};
 
 /// Get the directory where the Nushell executable is located.
@@ -54,6 +56,22 @@ pub(crate) fn find_nurfile<P: AsRef<Path>>(
     }
 
     None
+}
+
+// Copy of nushell: src/config_files.rs -> read_and_sort_directory
+pub(crate) fn read_and_sort_directory(path: &Path) -> Result<Vec<String>> {
+    let mut entries = Vec::new();
+
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let file_name_str = file_name.into_string().unwrap_or_default();
+        entries.push(file_name_str);
+    }
+
+    entries.sort();
+
+    Ok(entries)
 }
 
 #[cfg(test)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,8 +4,8 @@ use nu_protocol::engine::EngineState;
 use crate::args::{NurArgs, gather_commandline_args, parse_commandline_args};
 use crate::errors::{NurError, NurResult};
 use crate::names::{
-    NUR_CONFIG_CONFIG_FILENAME, NUR_CONFIG_DIR, NUR_CONFIG_ENV_FILENAME, NUR_CONFIG_LIB_PATH,
-    NUR_FILE, NUR_FILE_DOT_NU, NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU,
+    NUR_CONFIG_AUTOLOAD_DIR, NUR_CONFIG_CONFIG_FILENAME, NUR_CONFIG_DIR, NUR_CONFIG_ENV_FILENAME,
+    NUR_CONFIG_LIB_PATH, NUR_FILE, NUR_FILE_DOT_NU, NUR_LOCAL_FILE, NUR_LOCAL_FILE_DOT_NU,
 };
 use crate::path::{find_nurfile, find_project_path};
 use std::path::PathBuf;
@@ -20,6 +20,7 @@ pub(crate) struct NurState {
     pub(crate) lib_dir_path: PathBuf,
     pub(crate) env_path: PathBuf,
     pub(crate) config_path: PathBuf,
+    pub(crate) autoload_dirs: Vec<PathBuf>,
 
     pub(crate) nurfile_path: Option<PathBuf>,
     pub(crate) local_nurfile_path: Option<PathBuf>,
@@ -77,6 +78,7 @@ impl NurState {
         let lib_dir_path = config_dir.join(NUR_CONFIG_LIB_PATH);
         let env_path = config_dir.join(NUR_CONFIG_ENV_FILENAME);
         let config_path = config_dir.join(NUR_CONFIG_CONFIG_FILENAME);
+        let autoload_dirs = vec![config_dir.join(NUR_CONFIG_AUTOLOAD_DIR)];
 
         // Set nurfiles
         let nurfile_path = find_nurfile(&project_path, &nurfile_names);
@@ -91,6 +93,7 @@ impl NurState {
             lib_dir_path,
             env_path,
             config_path,
+            autoload_dirs,
 
             nurfile_path,
             local_nurfile_path,


### PR DESCRIPTION
# Description

`nur` will now load files from `.nur/autoload/` automatically.

This allows you to have your nur split into several files.

The autoload directories are available through `$nur.autoload-dirs`.
