### PR TITLE
Fix issue with nur panicing on --help with invalid task name

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -374,7 +374,7 @@ impl NurEngine {
     }
 
     pub(crate) fn get_task_def(&mut self) -> Option<&dyn Command> {
-        let task_name = self.state.task_name.clone().unwrap();
+        let task_name = self.state.task_name.clone()?;
 
         self.get_def(task_name)
     }


### PR DESCRIPTION
# Description

nur was panicing when you used `--help` with an invalid task name. This is now resolved. Instead an error is shown, that the task cannot be found.
